### PR TITLE
Add jdk8 under debian for arm64 arch

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,6 +11,7 @@ group "linux-arm64" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk8",
   ]
 }
 
@@ -61,7 +62,7 @@ target "debian_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk8",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk8",
   ]
-  platforms = ["linux/amd64"]
+  platforms = ["linux/amd64", "linux/arm64",]
 }
 
 target "debian_jdk11" {


### PR DESCRIPTION
The build for aarch64 (arm64) does work for me on my Raspberry Pi 3B+ running Armbian 22.05.0-trunk.0004 Focal with bleeding edge Linux 5.16.11-bcm2711.