### PR TITLE
Bump node Edge Version to 20.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-%: prepare-test
 	set -x
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:20.6.0-alpine3.18 \
+	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18.18.0-alpine3.18 \
 		sh -c "npm install -g npm@10.1.0 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-%: prepare-test
 	set -x
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18.18.0-alpine3.18 \
+	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:20.7.0-alpine3.18 \
 		sh -c "npm install -g npm@10.1.0 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test


### PR DESCRIPTION



<Actions>
    <action id="c4421e860b08a7c9d3b6af59f1f4ce30fe30d9918d40910c71c1fef33a43eaca">
        <h3>Bumps the node docker images version</h3>
        <details id="621987d2185dcc159fa0fb885b9a8af3f81bb5ab0f4a364973802b392538224e">
            <summary>Updates the value of the edge node docker image in the Makefile</summary>
            <p>1 file(s) updated with &#34;${1}node:20.7.0-alpine3.18${2}&#34;:&#xA;&#x9;* Makefile&#xA;</p>
            <details>
                <summary>20.7.0</summary>
                <pre>&#xA;Release published on the 2023-09-18 19:01:31 +0000 UTC at the url https://github.com/nodejs/node/releases/tag/v20.7.0&#xA;&#xA;### Notable Changes&#xD;&#xA;&#xD;&#xA;* \[[`022f1b70c1`](https://github.com/nodejs/node/commit/022f1b70c1)] - **src**: support multiple `--env-file` declarations (Yagiz Nizipli) [#49542](https://github.com/nodejs/node/pull/49542)&#xD;&#xA;* \[[`4a1d1cad61`](https://github.com/nodejs/node/commit/4a1d1cad61)] - **crypto**: update root certificates to NSS 3.93 (Node.js GitHub Bot) [#49341](https://github.com/nodejs/node/pull/49341)&#xD;&#xA;* \[[`a1a65f593c`](https://github.com/nodejs/node/commit/a1a65f593c)] - **deps**: upgrade npm to 10.1.0 (npm team) [#49570](https://github.com/nodejs/node/pull/49570)&#xD;&#xA;* \[[`6c2480cad9`](https://github.com/nodejs/node/commit/6c2480cad9)] - **(SEMVER-MINOR)** **deps**: upgrade npm to 10.0.0 (npm team) [#49423](https://github.com/nodejs/node/pull/49423)&#xD;&#xA;* \[[`bef900e56b`](https://github.com/nodejs/node/commit/bef900e56b)] - **doc**: move and rename loaders section (Geoffrey Booth) [#49261](https://github.com/nodejs/node/pull/49261)&#xD;&#xA;* \[[`db4ce8a593`](https://github.com/nodejs/node/commit/db4ce8a593)] - **doc**: add release key for Ulises Gascon (Ulises Gascón) [#49196](https://github.com/nodejs/node/pull/49196)&#xD;&#xA;* \[[`11c85ffa98`](https://github.com/nodejs/node/commit/11c85ffa98)] - **(SEMVER-MINOR)** **lib**: add api to detect whether source-maps are enabled (翠 / green) [#46391](https://github.com/nodejs/node/pull/46391)&#xD;&#xA;* \[[`ec51e25ed7`](https://github.com/nodejs/node/commit/ec51e25ed7)] - **src,permission**: add multiple allow-fs-\* flags (Carlos Espa) [#49047](https://github.com/nodejs/node/pull/49047)&#xD;&#xA;* \[[`efdc95fbc0`](https://github.com/nodejs/node/commit/efdc95fbc0)] - **(SEMVER-MINOR)** **test\_runner**: expose location of tests (Colin Ihrig) [#48975](https://github.com/nodejs/node/pull/48975)&#xD;&#xA;&#xD;&#xA;### Commits&#xD;&#xA;&#xD;&#xA;* \[[`e84515594e`](https://github.com/nodejs/node/commit/e84515594e)] - **benchmark**: use `tmpdir.resolve()` (Livia Medeiros) [#49137](https://github.com/nodejs/node/pull/49137)&#xD;&#xA;* \[[`f37444e896`](https://github.com/nodejs/node/commit/f37444e896)] - **bootstrap**: build code cache from deserialized isolate (Joyee Cheung) [#49099](https://github.com/nodejs/node/pull/49099)&#xD;&#xA;* \[[`af6dc1754d`](https://github.com/nodejs/node/commit/af6dc1754d)] - **bootstrap**: do not generate code cache in an unfinalized isolate (Joyee Cheung) [#49108](https://github.com/nodejs/node/pull/49108)&#xD;&#xA;* \[[`cade5716df`](https://github.com/nodejs/node/commit/cade5716df)] - **build**: add symlink to `compile_commands.json` file if needed (Juan José) [#49260](https://github.com/nodejs/node/pull/49260)&#xD;&#xA;* \[[`34a2590b05`](https://github.com/nodejs/node/commit/34a2590b05)] - **build**: expand when we run internet tests (Michael Dawson) [#49218](https://github.com/nodejs/node/pull/49218)&#xD;&#xA;* \[[`f637fd46ab`](https://github.com/nodejs/node/commit/f637fd46ab)] - **build**: fix typo `libray` -&gt; `library` (configure.py) (michalbiesek) [#49106](https://github.com/nodejs/node/pull/49106)&#xD;&#xA;* \[[`ef3d8dd493`](https://github.com/nodejs/node/commit/ef3d8dd493)] - **crypto**: remove webcrypto EdDSA key checks and properties (Filip Skokan) [#49408](https://github.com/nodejs/node/pull/49408)&#xD;&#xA;* \[[`4a1d1cad61`](https://github.com/nodejs/node/commit/4a1d1cad61)] - **crypto**: update root certificates to NSS 3.93 (Node.js GitHub Bot) [#49341](https://github.com/nodejs/node/pull/49341)&#xD;&#xA;* \[[`7eb10a38ea`](https://github.com/nodejs/node/commit/7eb10a38ea)] - **crypto**: remove getDefaultEncoding() (Tobias Nießen) [#49170](https://github.com/nodejs/node/pull/49170)&#xD;&#xA;* \[[`772496c030`](https://github.com/nodejs/node/commit/772496c030)] - **crypto**: remove default encoding from DiffieHellman (Tobias Nießen) [#49169](https://github.com/nodejs/node/pull/49169)&#xD;&#xA;* \[[`c795083232`](https://github.com/nodejs/node/commit/c795083232)] - **crypto**: remove default encoding from Hash/Hmac (Tobias Nießen) [#49167](https://github.com/nodejs/node/pull/49167)&#xD;&#xA;* \[[`08197aa010`](https://github.com/nodejs/node/commit/08197aa010)] - **crypto**: remove default encoding from sign/verify (Tobias Nießen) [#49145](https://github.com/nodejs/node/pull/49145)&#xD;&#xA;* \[[`a1a65f593c`](https://github.com/nodejs/node/commit/a1a65f593c)] - **deps**: upgrade npm to 10.1.0 (npm team) [#49570](https://github.com/nodejs/node/pull/49570)&#xD;&#xA;* \[[`6c2480cad9`](https://github.com/nodejs/node/commit/6c2480cad9)] - **(SEMVER-MINOR)** **deps**: upgrade npm to 10.0.0 (npm team) [#49423](https://github.com/nodejs/node/pull/49423)&#xD;&#xA;* \[[`84195d9584`](https://github.com/nodejs/node/commit/84195d9584)] - **deps**: add missing thread-common.c in uv.gyp (Santiago Gimeno) [#49410](https://github.com/nodejs/node/pull/49410)&#xD;&#xA;* \[[`5b70b68b3d`](https://github.com/nodejs/node/commit/5b70b68b3d)] - **deps**: V8: cherry-pick eadaef581c29 (Adam Majer) [#49401](https://github.com/nodejs/node/pull/49401)&#xD;&#xA;* \[[`fe34d632e8`](https://github.com/nodejs/node/commit/fe34d632e8)] - **deps**: update zlib to 1.2.13.1-motley-f5fd0ad (Node.js GitHub Bot) [#49252](https://github.com/nodejs/node/pull/49252)&#xD;&#xA;* \[[`db4ce8a593`](https://github.com/nodejs/node/commit/db4ce8a593)] - **doc**: add release key for Ulises Gascon (Ulises Gascón) [#49196](https://github.com/nodejs/node/pull/49196)&#xD;&#xA;* \[[`e5f3a694cf`](https://github.com/nodejs/node/commit/e5f3a694cf)] - **doc**: fix node-api call example (Chengzhong Wu) [#49395](https://github.com/nodejs/node/pull/49395)&#xD;&#xA;* \[[`021345a724`](https://github.com/nodejs/node/commit/021345a724)] - **doc**: add news issue for Diagnostics WG (Michael Dawson) [#49306](https://github.com/nodejs/node/pull/49306)&#xD;&#xA;* \[[`f82347266b`](https://github.com/nodejs/node/commit/f82347266b)] - **doc**: clarify policy expectations (Rafael Gonzaga) [#48947](https://github.com/nodejs/node/pull/48947)&#xD;&#xA;* \[[`73cfd9c895`](https://github.com/nodejs/node/commit/73cfd9c895)] - **doc**: add print results for examples in `StringDecoder` (Jungku Lee) [#49326](https://github.com/nodejs/node/pull/49326)&#xD;&#xA;* \[[`63ab591416`](https://github.com/nodejs/node/commit/63ab591416)] - **doc**: update outdated reference to NIST SP 800-131A (Tobias Nießen) [#49316](https://github.com/nodejs/node/pull/49316)&#xD;&#xA;* \[[`935dfe2afd`](https://github.com/nodejs/node/commit/935dfe2afd)] - **doc**: use `cjs` as block code&#39;s type in `MockTimers` (Deokjin Kim) [#49309](https://github.com/nodejs/node/pull/49309)&#xD;&#xA;* \[[`7c0cd2fb87`](https://github.com/nodejs/node/commit/7c0cd2fb87)] - **doc**: update `options.filter` description for `fs.cp` (Shubham Pandey) [#49289](https://github.com/nodejs/node/pull/49289)&#xD;&#xA;* \[[`f72e79ea67`](https://github.com/nodejs/node/commit/f72e79ea67)] - **doc**: add riscv64 to list of architectures (Stewart X Addison) [#49284](https://github.com/nodejs/node/pull/49284)&#xD;&#xA;* \[[`d19c710064`](https://github.com/nodejs/node/commit/d19c710064)] - **doc**: avoid &#34;not currently recommended&#34; (Tobias Nießen) [#49300](https://github.com/nodejs/node/pull/49300)&#xD;&#xA;* \[[`ae656101c0`](https://github.com/nodejs/node/commit/ae656101c0)] - **doc**: update module hooks docs (Geoffrey Booth) [#49265](https://github.com/nodejs/node/pull/49265)&#xD;&#xA;* \[[`fefbdb92f2`](https://github.com/nodejs/node/commit/fefbdb92f2)] - **doc**: modify param description for end(),write() in `StringDecoder` (Jungku Lee) [#49285](https://github.com/nodejs/node/pull/49285)&#xD;&#xA;* \[[`59e66a1ebe`](https://github.com/nodejs/node/commit/59e66a1ebe)] - **doc**: use NODE\_API\_SUPPORTED\_VERSION\_MAX in release doc (Cheng Zhao) [#49268](https://github.com/nodejs/node/pull/49268)&#xD;&#xA;* \[[`ac3b88449b`](https://github.com/nodejs/node/commit/ac3b88449b)] - **doc**: fix typo in `stream.finished` documentation (Antoine du Hamel) [#49271](https://github.com/nodejs/node/pull/49271)&#xD;&#xA;* \[[`7428ebf6c3`](https://github.com/nodejs/node/commit/7428ebf6c3)] - **doc**: update description for `percent_encode` sets in `WHATWG API` (Jungku Lee) [#49258](https://github.com/nodejs/node/pull/49258)&#xD;&#xA;* \[[`bef900e56b`](https://github.com/nodejs/node/commit/bef900e56b)] - **doc**: move and rename loaders section (Geoffrey Booth) [#49261](https://github.com/nodejs/node/pull/49261)&#xD;&#xA;* \[[`a22e0d9696`](https://github.com/nodejs/node/commit/a22e0d9696)] - **doc**: clarify use of Uint8Array for n-api (Fedor Indutny) [#48742](https://github.com/nodejs/node/pull/48742)&#xD;&#xA;* \[[`1704f24cb9`](https://github.com/nodejs/node/commit/1704f24cb9)] - **doc**: add signature for `module.register` (Geoffrey Booth) [#49251](https://github.com/nodejs/node/pull/49251)&#xD;&#xA;* \[[`5a363bb01b`](https://github.com/nodejs/node/commit/5a363bb01b)] - **doc**: caveat unavailability of `import.meta.resolve` in custom loaders (Jacob Smith) [#49242](https://github.com/nodejs/node/pull/49242)&#xD;&#xA;* \[[`8101f2b259`](https://github.com/nodejs/node/commit/8101f2b259)] - **doc**: use same name in the doc as in the code (Hyunjin Kim) [#49216](https://github.com/nodejs/node/pull/49216)&#xD;&#xA;* \[[`edf278d60d`](https://github.com/nodejs/node/commit/edf278d60d)] - **doc**: add notable-change label mention to PR template (Rafael Gonzaga) [#49188](https://github.com/nodejs/node/pull/49188)&#xD;&#xA;* \[[`3df2251a6a`](https://github.com/nodejs/node/commit/3df2251a6a)] - **doc**: add h1 summary to security release process (Rafael Gonzaga) [#49112](https://github.com/nodejs/node/pull/49112)&#xD;&#xA;* \[[`9fcd99a744`](https://github.com/nodejs/node/commit/9fcd99a744)] - **doc**: update to semver-minor releases by default (Rafael Gonzaga) [#49175](https://github.com/nodejs/node/pull/49175)&#xD;&#xA;* \[[`777931f499`](https://github.com/nodejs/node/commit/777931f499)] - **doc**: fix wording in napi\_async\_init (Tobias Nießen) [#49180](https://github.com/nodejs/node/pull/49180)&#xD;&#xA;* \[[`f45c8e10c0`](https://github.com/nodejs/node/commit/f45c8e10c0)] - **doc,test**: add known path resolution issue in permission model (Tobias Nießen) [#49155](https://github.com/nodejs/node/pull/49155)&#xD;&#xA;* \[[`a6cfea3f74`](https://github.com/nodejs/node/commit/a6cfea3f74)] - **esm**: align sync and async load implementations (Antoine du Hamel) [#49152](https://github.com/nodejs/node/pull/49152)&#xD;&#xA;* \[[`9fac310b33`](https://github.com/nodejs/node/commit/9fac310b33)] - **fs**: add the options param description in openAsBlob() (Yeseul Lee) [#49308](https://github.com/nodejs/node/pull/49308)&#xD;&#xA;* \[[`92772a8175`](https://github.com/nodejs/node/commit/92772a8175)] - **fs**: remove redundant code in readableWebStream() (Deokjin Kim) [#49298](https://github.com/nodejs/node/pull/49298)&#xD;&#xA;* \[[`88ba79b083`](https://github.com/nodejs/node/commit/88ba79b083)] - **fs**: make sure to write entire buffer (Robert Nagy) [#49211](https://github.com/nodejs/node/pull/49211)&#xD;&#xA;* \[[`11c85ffa98`](https://github.com/nodejs/node/commit/11c85ffa98)] - **(SEMVER-MINOR)** **lib**: add api to detect whether source-maps are enabled (翠 / green) [#46391](https://github.com/nodejs/node/pull/46391)&#xD;&#xA;* \[[`c12711ebfe`](https://github.com/nodejs/node/commit/c12711ebfe)] - **lib**: implement WeakReference on top of JS WeakRef (Joyee Cheung) [#49053](https://github.com/nodejs/node/pull/49053)&#xD;&#xA;* \[[`9a0891f88d`](https://github.com/nodejs/node/commit/9a0891f88d)] - **meta**: bump step-security/harden-runner from 2.5.0 to 2.5.1 (dependabot\[bot]) [#49435](https://github.com/nodejs/node/pull/49435)&#xD;&#xA;* \[[`ae67f41ef1`](https://github.com/nodejs/node/commit/ae67f41ef1)] - **meta**: bump actions/checkout from 3.5.3 to 3.6.0 (dependabot\[bot]) [#49436](https://github.com/nodejs/node/pull/49436)&#xD;&#xA;* \[[`71b4411fb2`](https://github.com/nodejs/node/commit/71b4411fb2)] - **meta**: bump actions/setup-node from 3.7.0 to 3.8.1 (dependabot\[bot]) [#49434](https://github.com/nodejs/node/pull/49434)&#xD;&#xA;* \[[`83b7d3a395`](https://github.com/nodejs/node/commit/83b7d3a395)] - **meta**: remove modules team from CODEOWNERS (Benjamin Gruenbaum) [#49412](https://github.com/nodejs/node/pull/49412)&#xD;&#xA;* \[[`81ff68c45c`](https://github.com/nodejs/node/commit/81ff68c45c)] - **meta**: move one or more collaborators to emeritus (Node.js GitHub Bot) [#49264](https://github.com/nodejs/node/pull/49264)&#xD;&#xA;* \[[`ab975233cc`](https://github.com/nodejs/node/commit/ab975233cc)] - **meta**: mention nodejs/tsc when changing GH templates (Rafael Gonzaga) [#49189](https://github.com/nodejs/node/pull/49189)&#xD;&#xA;* \[[`ceaa5494de`](https://github.com/nodejs/node/commit/ceaa5494de)] - **meta**: add test/reporters to codeowners (Chemi Atlow) [#49186](https://github.com/nodejs/node/pull/49186)&#xD;&#xA;* \[[`de0a51b7cf`](https://github.com/nodejs/node/commit/de0a51b7cf)] - **net**: improve performance of isIPv4 and isIPv6 (Uzlopak) [#49568](https://github.com/nodejs/node/pull/49568)&#xD;&#xA;* \[[`8d0913bf95`](https://github.com/nodejs/node/commit/8d0913bf95)] - **net**: use asserts in JS Socket Stream to catch races in future (Tim Perry) [#49400](https://github.com/nodejs/node/pull/49400)&#xD;&#xA;* \[[`2486836a7d`](https://github.com/nodejs/node/commit/2486836a7d)] - **net**: fix crash due to simultaneous close/shutdown on JS Stream Sockets (Tim Perry) [#49400](https://github.com/nodejs/node/pull/49400)&#xD;&#xA;* \[[`7a808340cd`](https://github.com/nodejs/node/commit/7a808340cd)] - **node-api**: fix compiler warning in node\_api.h (Michael Graeb) [#49103](https://github.com/nodejs/node/pull/49103)&#xD;&#xA;* \[[`30f26a99f4`](https://github.com/nodejs/node/commit/30f26a99f4)] - **permission**: ensure to resolve path when calling mkdtemp (RafaelGSS) [nodejs-private/node-private#440](https://github.com/nodejs-private/node-private/pull/440)&#xD;&#xA;* \[[`5051c75a5b`](https://github.com/nodejs/node/commit/5051c75a5b)] - **policy**: fix path to URL conversion (Antoine du Hamel) [#49133](https://github.com/nodejs/node/pull/49133)&#xD;&#xA;* \[[`173aed4757`](https://github.com/nodejs/node/commit/173aed4757)] - **report**: fix recent coverity warning (Michael Dawson) [#48954](https://github.com/nodejs/node/pull/48954)&#xD;&#xA;* \[[`d7ff78b442`](https://github.com/nodejs/node/commit/d7ff78b442)] - **sea**: generate code cache with deserialized isolate (Joyee Cheung) [#49226](https://github.com/nodejs/node/pull/49226)&#xD;&#xA;* \[[`022f1b70c1`](https://github.com/nodejs/node/commit/022f1b70c1)] - **src**: support multiple `--env-file` declarations (Yagiz Nizipli) [#49542](https://github.com/nodejs/node/pull/49542)&#xD;&#xA;* \[[`154b1c2115`](https://github.com/nodejs/node/commit/154b1c2115)] - **src**: don&#39;t overwrite environment from .env file (Phil Nash) [#49424](https://github.com/nodejs/node/pull/49424)&#xD;&#xA;* \[[`dc4de1c69b`](https://github.com/nodejs/node/commit/dc4de1c69b)] - **src**: modify code for empty string (pluris) [#49336](https://github.com/nodejs/node/pull/49336)&#xD;&#xA;* \[[`701c46f967`](https://github.com/nodejs/node/commit/701c46f967)] - **src**: remove unused PromiseWrap-related code (Joyee Cheung) [#49335](https://github.com/nodejs/node/pull/49335)&#xD;&#xA;* \[[`4a094dc7af`](https://github.com/nodejs/node/commit/4a094dc7af)] - **src**: rename IsAnyByteSource to IsAnyBufferSource (Tobias Nießen) [#49346](https://github.com/nodejs/node/pull/49346)&#xD;&#xA;* \[[`55d6649175`](https://github.com/nodejs/node/commit/55d6649175)] - **src**: support snapshot deserialization in RAIIIsolate (Joyee Cheung) [#49226](https://github.com/nodejs/node/pull/49226)&#xD;&#xA;* \[[`dc092864ef`](https://github.com/nodejs/node/commit/dc092864ef)] - **src**: remove unused function `GetName()` in node\_perf (Jungku Lee) [#49244](https://github.com/nodejs/node/pull/49244)&#xD;&#xA;* \[[`f2552a410e`](https://github.com/nodejs/node/commit/f2552a410e)] - **src**: use ARES\_SUCCESS instead of 0 (Jungku Lee) [#49048](https://github.com/nodejs/node/pull/49048)&#xD;&#xA;* \[[`4a9ae31519`](https://github.com/nodejs/node/commit/4a9ae31519)] - **src**: add a condition if the argument of `DomainToUnicode` is empty (Jungku Lee) [#49097](https://github.com/nodejs/node/pull/49097)&#xD;&#xA;* \[[`f460362cdf`](https://github.com/nodejs/node/commit/f460362cdf)] - **src**: remove C++ WeakReference implementation (Joyee Cheung) [#49053](https://github.com/nodejs/node/pull/49053)&#xD;&#xA;* \[[`2a35383b3e`](https://github.com/nodejs/node/commit/2a35383b3e)] - **src**: use per-realm GetBindingData() wherever applicable (Joyee Cheung) [#49007](https://github.com/nodejs/node/pull/49007)&#xD;&#xA;* \[[`184bbddcf5`](https://github.com/nodejs/node/commit/184bbddcf5)] - **src**: add per-realm GetBindingData() method (Joyee Cheung) [#49007](https://github.com/nodejs/node/pull/49007)&#xD;&#xA;* \[[`e9946885f9`](https://github.com/nodejs/node/commit/e9946885f9)] - **src**: serialize both BaseObject slots (Joyee Cheung) [#48996](https://github.com/nodejs/node/pull/48996)&#xD;&#xA;* \[[`ec51e25ed7`](https://github.com/nodejs/node/commit/ec51e25ed7)] - **src,permission**: add multiple allow-fs-\* flags (Carlos Espa) [#49047](https://github.com/nodejs/node/pull/49047)&#xD;&#xA;* \[[`8aac95de4b`](https://github.com/nodejs/node/commit/8aac95de4b)] - **stream**: improve tee perf by reduce `ReflectConstruct` usages (Raz Luvaton) [#49546](https://github.com/nodejs/node/pull/49546)&#xD;&#xA;* \[[`0eea7fd8fb`](https://github.com/nodejs/node/commit/0eea7fd8fb)] - **stream**: use Buffer.from when constructor is a Buffer (Matthew Aitken) [#49250](https://github.com/nodejs/node/pull/49250)&#xD;&#xA;* \[[`b961d9bd52`](https://github.com/nodejs/node/commit/b961d9bd52)] - **stream**: add `highWaterMark` for the map operator (Raz Luvaton) [#49249](https://github.com/nodejs/node/pull/49249)&#xD;&#xA;* \[[`ca1384166d`](https://github.com/nodejs/node/commit/ca1384166d)] - **test**: fix warning for comment in embedtest (Jungku Lee) [#49416](https://github.com/nodejs/node/pull/49416)&#xD;&#xA;* \[[`2a35782809`](https://github.com/nodejs/node/commit/2a35782809)] - **test**: simplify test-crypto-dh-group-setters (Tobias Nießen) [#49404](https://github.com/nodejs/node/pull/49404)&#xD;&#xA;* \[[`6740f3c209`](https://github.com/nodejs/node/commit/6740f3c209)] - **test**: verify dynamic import call with absolute path strings (Chengzhong Wu) [#49275](https://github.com/nodejs/node/pull/49275)&#xD;&#xA;* \[[`6ed47bd8fb`](https://github.com/nodejs/node/commit/6ed47bd8fb)] - **test**: reduce length in crypto keygen tests (Joyee Cheung) [#49221](https://github.com/nodejs/node/pull/49221)&#xD;&#xA;* \[[`4faa30c553`](https://github.com/nodejs/node/commit/4faa30c553)] - **test**: split JWK async elliptic curve keygen tests (Joyee Cheung) [#49221](https://github.com/nodejs/node/pull/49221)&#xD;&#xA;* \[[`e04a2603d8`](https://github.com/nodejs/node/commit/e04a2603d8)] - **test**: split test-crypto-keygen.js (Joyee Cheung) [#49221](https://github.com/nodejs/node/pull/49221)&#xD;&#xA;* \[[`0d23c1d4ce`](https://github.com/nodejs/node/commit/0d23c1d4ce)] - **test**: rename test-crypto-modp1-error (Tobias Nießen) [#49348](https://github.com/nodejs/node/pull/49348)&#xD;&#xA;* \[[`48e41569e2`](https://github.com/nodejs/node/commit/48e41569e2)] - **test**: migrate message source map tests from Python to JS (Yiyun Lei) [#49238](https://github.com/nodejs/node/pull/49238)&#xD;&#xA;* \[[`a11e64e09c`](https://github.com/nodejs/node/commit/a11e64e09c)] - **test**: fix compiler warning in NodeCryptoEnv (Tobias Nießen) [#49206](https://github.com/nodejs/node/pull/49206)&#xD;&#xA;* \[[`345543938f`](https://github.com/nodejs/node/commit/345543938f)] - **test**: handle EUNATCH (Abdirahim Musse) [#48050](https://github.com/nodejs/node/pull/48050)&#xD;&#xA;* \[[`e391f4b197`](https://github.com/nodejs/node/commit/e391f4b197)] - **test**: use `tmpdir.resolve()` (Livia Medeiros) [#49136](https://github.com/nodejs/node/pull/49136)&#xD;&#xA;* \[[`910378f93f`](https://github.com/nodejs/node/commit/910378f93f)] - **test**: reduce flakiness of `test-esm-loader-hooks` (Antoine du Hamel) [#49248](https://github.com/nodejs/node/pull/49248)&#xD;&#xA;* \[[`4a85f70462`](https://github.com/nodejs/node/commit/4a85f70462)] - **test**: add spawnSyncAndExit() and spawnSyncAndExitWithoutError() (Joyee Cheung) [#49200](https://github.com/nodejs/node/pull/49200)&#xD;&#xA;* \[[`9610008b79`](https://github.com/nodejs/node/commit/9610008b79)] - **test**: make test-perf-hooks more robust and work with workers (Joyee Cheung) [#49197](https://github.com/nodejs/node/pull/49197)&#xD;&#xA;* \[[`dc8fff9a75`](https://github.com/nodejs/node/commit/dc8fff9a75)] - **test**: use gcUntil() in test-v8-serialize-leak (Joyee Cheung) [#49168](https://github.com/nodejs/node/pull/49168)&#xD;&#xA;* \[[`ca9f801332`](https://github.com/nodejs/node/commit/ca9f801332)] - **test**: make WeakReference tests robust (Joyee Cheung) [#49053](https://github.com/nodejs/node/pull/49053)&#xD;&#xA;* \[[`de103a4686`](https://github.com/nodejs/node/commit/de103a4686)] - **test**: add test for effect of UV\_THREADPOOL\_SIZE (Tobias Nießen) [#49165](https://github.com/nodejs/node/pull/49165)&#xD;&#xA;* \[[`47d24f144b`](https://github.com/nodejs/node/commit/47d24f144b)] - **test**: use expectSyncExit{WithErrors} in snapshot tests (Joyee Cheung) [#49020](https://github.com/nodejs/node/pull/49020)&#xD;&#xA;* \[[`c441f5a097`](https://github.com/nodejs/node/commit/c441f5a097)] - **test**: add expectSyncExitWithoutError() and expectSyncExit() utils (Joyee Cheung) [#49020](https://github.com/nodejs/node/pull/49020)&#xD;&#xA;* \[[`4d184b5251`](https://github.com/nodejs/node/commit/4d184b5251)] - **test**: remove --no-warnings flag in test\_runner fixtures (Raz Luvaton) [#48989](https://github.com/nodejs/node/pull/48989)&#xD;&#xA;* \[[`25e967a90b`](https://github.com/nodejs/node/commit/25e967a90b)] - **test**: reorder test files fixtures for better understanding (Raz Luvaton) [#48787](https://github.com/nodejs/node/pull/48787)&#xD;&#xA;* \[[`fac56dbcc0`](https://github.com/nodejs/node/commit/fac56dbcc0)] - **test,benchmark**: use `tmpdir.fileURL()` (Livia Medeiros) [#49138](https://github.com/nodejs/node/pull/49138)&#xD;&#xA;* \[[`36763fa532`](https://github.com/nodejs/node/commit/36763fa532)] - **test\_runner**: preserve original property descriptor (Erick Wendel) [#49433](https://github.com/nodejs/node/pull/49433)&#xD;&#xA;* \[[`40e9fcdbea`](https://github.com/nodejs/node/commit/40e9fcdbea)] - **test\_runner**: add support for setImmediate (Erick Wendel) [#49397](https://github.com/nodejs/node/pull/49397)&#xD;&#xA;* \[[`23216f1935`](https://github.com/nodejs/node/commit/23216f1935)] - **test\_runner**: report covered lines, functions and branches to reporters (Phil Nash) [#49320](https://github.com/nodejs/node/pull/49320)&#xD;&#xA;* \[[`283f2806b1`](https://github.com/nodejs/node/commit/283f2806b1)] - **test\_runner**: expose spec reporter as newable function (Chemi Atlow) [#49184](https://github.com/nodejs/node/pull/49184)&#xD;&#xA;* \[[`546ad5f770`](https://github.com/nodejs/node/commit/546ad5f770)] - **test\_runner**: reland run global after() hook earlier (Colin Ihrig) [#49116](https://github.com/nodejs/node/pull/49116)&#xD;&#xA;* \[[`efdc95fbc0`](https://github.com/nodejs/node/commit/efdc95fbc0)] - **(SEMVER-MINOR)** **test\_runner**: expose location of tests (Colin Ihrig) [#48975](https://github.com/nodejs/node/pull/48975)&#xD;&#xA;* \[[`4bc0a8fe99`](https://github.com/nodejs/node/commit/4bc0a8fe99)] - **test\_runner**: fix global after not failing the tests (Raz Luvaton) [#48913](https://github.com/nodejs/node/pull/48913)&#xD;&#xA;* \[[`08738b2664`](https://github.com/nodejs/node/commit/08738b2664)] - **test\_runner**: fix timeout in \*Each hook failing further tests (Raz Luvaton) [#48925](https://github.com/nodejs/node/pull/48925)&#xD;&#xA;* \[[`c2f1830f66`](https://github.com/nodejs/node/commit/c2f1830f66)] - **test\_runner**: cleanup test timeout abort listener (Raz Luvaton) [#48915](https://github.com/nodejs/node/pull/48915)&#xD;&#xA;* \[[`75333f38b2`](https://github.com/nodejs/node/commit/75333f38b2)] - **test\_runner**: fix global before not called when no global test exists (Raz Luvaton) [#48877](https://github.com/nodejs/node/pull/48877)&#xD;&#xA;* \[[`b28b85adf8`](https://github.com/nodejs/node/commit/b28b85adf8)] - **tls**: remove redundant code in onConnectSecure() (Deokjin Kim) [#49457](https://github.com/nodejs/node/pull/49457)&#xD;&#xA;* \[[`83fc4dccbc`](https://github.com/nodejs/node/commit/83fc4dccbc)] - **tls**: refactor to use validateFunction (Deokjin Kim) [#49422](https://github.com/nodejs/node/pull/49422)&#xD;&#xA;* \[[`8949cc79dd`](https://github.com/nodejs/node/commit/8949cc79dd)] - **tls**: ensure TLS Sockets are closed if the underlying wrap closes (Tim Perry) [#49327](https://github.com/nodejs/node/pull/49327)&#xD;&#xA;* \[[`1df56e6f01`](https://github.com/nodejs/node/commit/1df56e6f01)] - **tools**: update eslint to 8.48.0 (Node.js GitHub Bot) [#49343](https://github.com/nodejs/node/pull/49343)&#xD;&#xA;* \[[`ef50ec5b57`](https://github.com/nodejs/node/commit/ef50ec5b57)] - **tools**: update lint-md-dependencies (Node.js GitHub Bot) [#49342](https://github.com/nodejs/node/pull/49342)&#xD;&#xA;* \[[`9a8fb4fc34`](https://github.com/nodejs/node/commit/9a8fb4fc34)] - **tools**: remove v8\_dump\_build\_config action (Cheng Zhao) [#49301](https://github.com/nodejs/node/pull/49301)&#xD;&#xA;* \[[`91b2d4314b`](https://github.com/nodejs/node/commit/91b2d4314b)] - **tools**: update lint-md-dependencies (Node.js GitHub Bot) [#49253](https://github.com/nodejs/node/pull/49253)&#xD;&#xA;* \[[`b51946ebdd`](https://github.com/nodejs/node/commit/b51946ebdd)] - **tools**: fix github reporter appended multiple times (Moshe Atlow) [#49199](https://github.com/nodejs/node/pull/49199)&#xD;&#xA;* \[[`ae40cb1612`](https://github.com/nodejs/node/commit/ae40cb1612)] - **url**: validate `pathToFileURL(path)` argument as string (LiviaMedeiros) [#49161](https://github.com/nodejs/node/pull/49161)&#xD;&#xA;* \[[`e787673dcf`](https://github.com/nodejs/node/commit/e787673dcf)] - **url**: handle unicode hostname if empty (Yagiz Nizipli) [#49396](https://github.com/nodejs/node/pull/49396)&#xD;&#xA;* \[[`6ee74be87f`](https://github.com/nodejs/node/commit/6ee74be87f)] - **vm**: store MicrotaskQueue in ContextifyContext directly (Joyee Cheung) [#48982](https://github.com/nodejs/node/pull/48982)&#xD;&#xA;* \[[`0179c6dc8f`](https://github.com/nodejs/node/commit/0179c6dc8f)] - **worker**: protect against user mutating well-known prototypes (Antoine du Hamel) [#49270](https://github.com/nodejs/node/pull/49270)</pre>
            </details>
        </details>
    </action>
    <action id="c98c7aef222c65e57028290c077f658d2bdc8d0ec29dfe77037eed03ee255bda">
        <h3>Bumps the node docker images version</h3>
        <details id="056ff5cd4e1302dc8aef191e9c02af280a674bffcf32b77a1baa39bd3b5d0e88">
            <summary>Updates the value of the LTS node docker image in the Makefile</summary>
            <p>1 file(s) updated with &#34;${1}node:18.18.0-alpine3.18${2}&#34;:&#xA;&#x9;* Makefile&#xA;</p>
            <details>
                <summary>18.18.0</summary>
                <pre>&#xA;Release published on the 2023-09-18 22:00:28 +0000 UTC at the url https://github.com/nodejs/node/releases/tag/v18.18.0&#xA;&#xA;### Notable Changes&#xD;&#xA;&#xD;&#xA;* \[[`7dc731d4bf`](https://github.com/nodejs/node/commit/7dc731d4bf)] - **build**: sync libuv header change (Jiawen Geng) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`490fc004b0`](https://github.com/nodejs/node/commit/490fc004b0)] - **crypto**: update root certificates to NSS 3.93 (Node.js GitHub Bot) [#49341](https://github.com/nodejs/node/pull/49341)&#xD;&#xA;* \[[`dd8cd97d4d`](https://github.com/nodejs/node/commit/dd8cd97d4d)] - **crypto**: update root certificates to NSS 3.90 (Node.js GitHub Bot) [#48416](https://github.com/nodejs/node/pull/48416)&#xD;&#xA;* \[[`ea23870bec`](https://github.com/nodejs/node/commit/ea23870bec)] - **deps**: add missing thread-common.c in uv.gyp (Santiago Gimeno) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`88855e0b1b`](https://github.com/nodejs/node/commit/88855e0b1b)] - **deps**: upgrade to libuv 1.46.0 (Santiago Gimeno) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`fb2b80fca0`](https://github.com/nodejs/node/commit/fb2b80fca0)] - **deps**: upgrade to libuv 1.45.0 (Santiago Gimeno) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`249879e46c`](https://github.com/nodejs/node/commit/249879e46c)] - **doc**: add atlowChemi to collaborators (atlowChemi) [#48757](https://github.com/nodejs/node/pull/48757)&#xD;&#xA;* \[[`e8dc7bde6a`](https://github.com/nodejs/node/commit/e8dc7bde6a)] - **doc**: add vmoroz to collaborators (Vladimir Morozov) [#48527](https://github.com/nodejs/node/pull/48527)&#xD;&#xA;* \[[`a30f2fbcc1`](https://github.com/nodejs/node/commit/a30f2fbcc1)] - **doc**: add kvakil to collaborators (Keyhan Vakil) [#48449](https://github.com/nodejs/node/pull/48449)&#xD;&#xA;* \[[`c39b7c240e`](https://github.com/nodejs/node/commit/c39b7c240e)] - **(SEMVER-MINOR)** **esm**: add `--import` flag (Moshe Atlow) [#43942](https://github.com/nodejs/node/pull/43942)&#xD;&#xA;* \[[`a68a67f54d`](https://github.com/nodejs/node/commit/a68a67f54d)] - **(SEMVER-MINOR)** **events**: allow safely adding listener to abortSignal (Chemi Atlow) [#48596](https://github.com/nodejs/node/pull/48596)&#xD;&#xA;* \[[`3a8586bee2`](https://github.com/nodejs/node/commit/3a8586bee2)] - **fs, stream**: initial `Symbol.dispose` and `Symbol.asyncDispose` support (Moshe Atlow) [#48518](https://github.com/nodejs/node/pull/48518)&#xD;&#xA;* \[[`863bdb785d`](https://github.com/nodejs/node/commit/863bdb785d)] - **net**: add autoSelectFamily global getter and setter (Paolo Insogna) [#45777](https://github.com/nodejs/node/pull/45777)&#xD;&#xA;* \[[`c59ae86ba0`](https://github.com/nodejs/node/commit/c59ae86ba0)] - **(SEMVER-MINOR)** **url**: add value argument to has and delete methods (Sankalp Shubham) [#47885](https://github.com/nodejs/node/pull/47885)&#xD;&#xA;&#xD;&#xA;### Commits&#xD;&#xA;&#xD;&#xA;* \[[`d1f43317ea`](https://github.com/nodejs/node/commit/d1f43317ea)] - **benchmark**: add bar.R (Rafael Gonzaga) [#47729](https://github.com/nodejs/node/pull/47729)&#xD;&#xA;* \[[`4f74be3c92`](https://github.com/nodejs/node/commit/4f74be3c92)] - **benchmark**: refactor crypto oneshot (Filip Skokan) [#48267](https://github.com/nodejs/node/pull/48267)&#xD;&#xA;* \[[`fe9da9df0f`](https://github.com/nodejs/node/commit/fe9da9df0f)] - **benchmark**: add crypto.create\*Key (Filip Skokan) [#48284](https://github.com/nodejs/node/pull/48284)&#xD;&#xA;* \[[`9cb18b3e9d`](https://github.com/nodejs/node/commit/9cb18b3e9d)] - **build**: do not pass target toolchain flags to host toolchain (Ivan Trubach) [#48597](https://github.com/nodejs/node/pull/48597)&#xD;&#xA;* \[[`7dc731d4bf`](https://github.com/nodejs/node/commit/7dc731d4bf)] - **build**: sync libuv header change (Jiawen Geng) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`211a4f88a9`](https://github.com/nodejs/node/commit/211a4f88a9)] - **build**: update action to close stale PRs (Michael Dawson) [#48196](https://github.com/nodejs/node/pull/48196)&#xD;&#xA;* \[[`cc33a1864b`](https://github.com/nodejs/node/commit/cc33a1864b)] - **child\_process**: harden against prototype pollution (Livia Medeiros) [#48726](https://github.com/nodejs/node/pull/48726)&#xD;&#xA;* \[[`b5df084e1e`](https://github.com/nodejs/node/commit/b5df084e1e)] - **child\_process**: use addAbortListener (atlowChemi) [#48550](https://github.com/nodejs/node/pull/48550)&#xD;&#xA;* \[[`611db8df1a`](https://github.com/nodejs/node/commit/611db8df1a)] - **child\_process**: support `Symbol.dispose` (Moshe Atlow) [#48551](https://github.com/nodejs/node/pull/48551)&#xD;&#xA;* \[[`490fc004b0`](https://github.com/nodejs/node/commit/490fc004b0)] - **crypto**: update root certificates to NSS 3.93 (Node.js GitHub Bot) [#49341](https://github.com/nodejs/node/pull/49341)&#xD;&#xA;* \[[`dd8cd97d4d`](https://github.com/nodejs/node/commit/dd8cd97d4d)] - **crypto**: update root certificates to NSS 3.90 (Node.js GitHub Bot) [#48416](https://github.com/nodejs/node/pull/48416)&#xD;&#xA;* \[[`b2bc839d4c`](https://github.com/nodejs/node/commit/b2bc839d4c)] - **crypto**: remove OPENSSL\_FIPS guard for OpenSSL 3 (Richard Lau) [#48392](https://github.com/nodejs/node/pull/48392)&#xD;&#xA;* \[[`c8da8c80b9`](https://github.com/nodejs/node/commit/c8da8c80b9)] - **deps**: update nghttp2 to 1.55.0 (Node.js GitHub Bot) [#48746](https://github.com/nodejs/node/pull/48746)&#xD;&#xA;* \[[`7e04242dcb`](https://github.com/nodejs/node/commit/7e04242dcb)] - **deps**: update minimatch to 9.0.3 (Node.js GitHub Bot) [#48704](https://github.com/nodejs/node/pull/48704)&#xD;&#xA;* \[[`ea23870bec`](https://github.com/nodejs/node/commit/ea23870bec)] - **deps**: add missing thread-common.c in uv.gyp (Santiago Gimeno) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`88855e0b1b`](https://github.com/nodejs/node/commit/88855e0b1b)] - **deps**: upgrade to libuv 1.46.0 (Santiago Gimeno) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`fb2b80fca0`](https://github.com/nodejs/node/commit/fb2b80fca0)] - **deps**: upgrade to libuv 1.45.0 (Santiago Gimeno) [#48078](https://github.com/nodejs/node/pull/48078)&#xD;&#xA;* \[[`59fca4e09a`](https://github.com/nodejs/node/commit/59fca4e09a)] - **deps**: update acorn to 8.10.0 (Node.js GitHub Bot) [#48713](https://github.com/nodejs/node/pull/48713)&#xD;&#xA;* \[[`bcb255d5a8`](https://github.com/nodejs/node/commit/bcb255d5a8)] - **deps**: V8: cherry-pick cb00db4dba6c (Keyhan Vakil) [#48671](https://github.com/nodejs/node/pull/48671)&#xD;&#xA;* \[[`65a6c90fc6`](https://github.com/nodejs/node/commit/65a6c90fc6)] - **deps**: update acorn to 8.9.0 (Node.js GitHub Bot) [#48484](https://github.com/nodejs/node/pull/48484)&#xD;&#xA;* \[[`6b6d5d91e9`](https://github.com/nodejs/node/commit/6b6d5d91e9)] - **deps**: update zlib to 1.2.13.1-motley-f81f385 (Node.js GitHub Bot) [#48541](https://github.com/nodejs/node/pull/48541)&#xD;&#xA;* \[[`56249b0770`](https://github.com/nodejs/node/commit/56249b0770)] - **deps**: update googletest to ec4fed9 (Node.js GitHub Bot) [#48538](https://github.com/nodejs/node/pull/48538)&#xD;&#xA;* \[[`8914a5204a`](https://github.com/nodejs/node/commit/8914a5204a)] - **deps**: update minimatch to 9.0.2 (Node.js GitHub Bot) [#48542](https://github.com/nodejs/node/pull/48542)&#xD;&#xA;* \[[`1b960d9988`](https://github.com/nodejs/node/commit/1b960d9988)] - **deps**: update icu to 73.2 (Node.js GitHub Bot) [#48502](https://github.com/nodejs/node/pull/48502)&#xD;&#xA;* \[[`f0e2e3c549`](https://github.com/nodejs/node/commit/f0e2e3c549)] - **deps**: update zlib to 1.2.13.1-motley-3ca9f16 (Node.js GitHub Bot) [#48413](https://github.com/nodejs/node/pull/48413)&#xD;&#xA;* \[[`9cf8fe6b93`](https://github.com/nodejs/node/commit/9cf8fe6b93)] - **deps**: upgrade npm to 9.8.1 (npm team) [#48838](https://github.com/nodejs/node/pull/48838)&#xD;&#xA;* \[[`d9ff473ff3`](https://github.com/nodejs/node/commit/d9ff473ff3)] - **deps**: upgrade npm to 9.8.0 (npm team) [#48665](https://github.com/nodejs/node/pull/48665)&#xD;&#xA;* \[[`4a6177daad`](https://github.com/nodejs/node/commit/4a6177daad)] - **deps**: upgrade npm to 9.7.2 (npm team) [#48514](https://github.com/nodejs/node/pull/48514)&#xD;&#xA;* \[[`104b58feb1`](https://github.com/nodejs/node/commit/104b58feb1)] - **deps**: update ada to 2.6.0 (Node.js GitHub Bot) [#48896](https://github.com/nodejs/node/pull/48896)&#xD;&#xA;* \[[`7f7a125d78`](https://github.com/nodejs/node/commit/7f7a125d78)] - **deps**: update corepack to 0.19.0 (Node.js GitHub Bot) [#48540](https://github.com/nodejs/node/pull/48540)&#xD;&#xA;* \[[`5e1eb451d1`](https://github.com/nodejs/node/commit/5e1eb451d1)] - **deps**: update corepack to 0.18.1 (Node.js GitHub Bot) [#48483](https://github.com/nodejs/node/pull/48483)&#xD;&#xA;* \[[`3be53358bc`](https://github.com/nodejs/node/commit/3be53358bc)] - **deps**: add loong64 config into openssl gypi (Shi Pujin) [#48043](https://github.com/nodejs/node/pull/48043)&#xD;&#xA;* \[[`555982c59e`](https://github.com/nodejs/node/commit/555982c59e)] - **deps**: upgrade npm to 9.7.1 (npm team) [#48378](https://github.com/nodejs/node/pull/48378)&#xD;&#xA;* \[[`3c03ec0832`](https://github.com/nodejs/node/commit/3c03ec0832)] - **deps**: update simdutf to 3.2.14 (Node.js GitHub Bot) [#48344](https://github.com/nodejs/node/pull/48344)&#xD;&#xA;* \[[`a2964a4583`](https://github.com/nodejs/node/commit/a2964a4583)] - **deps**: update ada to 2.5.1 (Node.js GitHub Bot) [#48319](https://github.com/nodejs/node/pull/48319)&#xD;&#xA;* \[[`38f6e0d8cd`](https://github.com/nodejs/node/commit/38f6e0d8cd)] - **deps**: update zlib to 982b036 (Node.js GitHub Bot) [#48327](https://github.com/nodejs/node/pull/48327)&#xD;&#xA;* \[[`f4617a4f81`](https://github.com/nodejs/node/commit/f4617a4f81)] - **deps**: add loongarch64 into openssl Makefile and gen openssl-loongarch64 (Shi Pujin) [#46401](https://github.com/nodejs/node/pull/46401)&#xD;&#xA;* \[[`573eb4be12`](https://github.com/nodejs/node/commit/573eb4be12)] - **dgram**: socket add `asyncDispose` (atlowChemi) [#48717](https://github.com/nodejs/node/pull/48717)&#xD;&#xA;* \[[`f3c4300e00`](https://github.com/nodejs/node/commit/f3c4300e00)] - **dgram**: use addAbortListener (atlowChemi) [#48550](https://github.com/nodejs/node/pull/48550)&#xD;&#xA;* \[[`d3041df738`](https://github.com/nodejs/node/commit/d3041df738)] - **doc**: expand on squashing and rebasing to land a PR (Chengzhong Wu) [#48751](https://github.com/nodejs/node/pull/48751)&#xD;&#xA;* \[[`249879e46c`](https://github.com/nodejs/node/commit/249879e46c)] - **doc**: add atlowChemi to collaborators (atlowChemi) [#48757](https://github.com/nodejs/node/pull/48757)&#xD;&#xA;* \[[`42ecd46d1f`](https://github.com/nodejs/node/commit/42ecd46d1f)] - **doc**: fix ambiguity in http.md and https.md (an5er) [#48692](https://github.com/nodejs/node/pull/48692)&#xD;&#xA;* \[[`e78824e053`](https://github.com/nodejs/node/commit/e78824e053)] - **doc**: add release key for Ulises Gascon (Ulises Gascón) [#49196](https://github.com/nodejs/node/pull/49196)&#xD;&#xA;* \[[`1aa798d69f`](https://github.com/nodejs/node/commit/1aa798d69f)] - **doc**: clarify transform.\_transform() callback argument logic (Rafael Sofi-zada) [#48680](https://github.com/nodejs/node/pull/48680)&#xD;&#xA;* \[[`d723e870a2`](https://github.com/nodejs/node/commit/d723e870a2)] - **doc**: mention git node release prepare (Rafael Gonzaga) [#48644](https://github.com/nodejs/node/pull/48644)&#xD;&#xA;* \[[`a9a1394388`](https://github.com/nodejs/node/commit/a9a1394388)] - **doc**: fix options order (Luigi Pinca) [#48617](https://github.com/nodejs/node/pull/48617)&#xD;&#xA;* \[[`989ea6858f`](https://github.com/nodejs/node/commit/989ea6858f)] - **doc**: update security release stewards (Rafael Gonzaga) [#48569](https://github.com/nodejs/node/pull/48569)&#xD;&#xA;* \[[`f436ac1803`](https://github.com/nodejs/node/commit/f436ac1803)] - **doc**: update return type for describe (Shrujal Shah) [#48572](https://github.com/nodejs/node/pull/48572)&#xD;&#xA;* \[[`fbe89e6320`](https://github.com/nodejs/node/commit/fbe89e6320)] - **doc**: run license-builder (github-actions\[bot]) [#48552](https://github.com/nodejs/node/pull/48552)&#xD;&#xA;* \[[`f18b287bc3`](https://github.com/nodejs/node/commit/f18b287bc3)] - **doc**: add description of autoAllocateChunkSize in ReadableStream (Debadree Chatterjee) [#48004](https://github.com/nodejs/node/pull/48004)&#xD;&#xA;* \[[`e2f3ed1444`](https://github.com/nodejs/node/commit/e2f3ed1444)] - **doc**: fix `filename` type in `watch` result (Dmitry Semigradsky) [#48032](https://github.com/nodejs/node/pull/48032)&#xD;&#xA;* \[[`1fe75dc2b0`](https://github.com/nodejs/node/commit/1fe75dc2b0)] - **doc**: unnest `mime` and `MIMEParams` from MIMEType constructor (Dmitry Semigradsky) [#47950](https://github.com/nodejs/node/pull/47950)&#xD;&#xA;* \[[`e1339d58e8`](https://github.com/nodejs/node/commit/e1339d58e8)] - **doc**: update security-release-process.md (Rafael Gonzaga) [#48504](https://github.com/nodejs/node/pull/48504)&#xD;&#xA;* \[[`e8dc7bde6a`](https://github.com/nodejs/node/commit/e8dc7bde6a)] - **doc**: add vmoroz to collaborators (Vladimir Morozov) [#48527](https://github.com/nodejs/node/pull/48527)&#xD;&#xA;* \[[`f8ba672c7b`](https://github.com/nodejs/node/commit/f8ba672c7b)] - **doc**: link to Runtime Keys in export conditions (Jacob Hummer) [#48408](https://github.com/nodejs/node/pull/48408)&#xD;&#xA;* \[[`0056cb93e9`](https://github.com/nodejs/node/commit/0056cb93e9)] - **doc**: update fs flags documentation (sinkhaha) [#48463](https://github.com/nodejs/node/pull/48463)&#xD;&#xA;* \[[`3cf3fb9479`](https://github.com/nodejs/node/commit/3cf3fb9479)] - **doc**: revise `error.md` introduction (Antoine du Hamel) [#48423](https://github.com/nodejs/node/pull/48423)&#xD;&#xA;* \[[`7575d8b90e`](https://github.com/nodejs/node/commit/7575d8b90e)] - **doc**: add preveen-stack to triagers (Preveen P) [#48387](https://github.com/nodejs/node/pull/48387)&#xD;&#xA;* \[[`820aa550a4`](https://github.com/nodejs/node/commit/820aa550a4)] - **doc**: refine when file is undefined in test events (Moshe Atlow) [#48451](https://github.com/nodejs/node/pull/48451)&#xD;&#xA;* \[[`a30f2fbcc1`](https://github.com/nodejs/node/commit/a30f2fbcc1)] - **doc**: add kvakil to collaborators (Keyhan Vakil) [#48449](https://github.com/nodejs/node/pull/48449)&#xD;&#xA;* \[[`239b4ea66f`](https://github.com/nodejs/node/commit/239b4ea66f)] - **doc**: mark `--import` as experimental (Moshe Atlow) [#44067](https://github.com/nodejs/node/pull/44067)&#xD;&#xA;* \[[`2a561aefe2`](https://github.com/nodejs/node/commit/2a561aefe2)] - **doc**: add additional info on TSFN dispatch (Michael Dawson) [#48367](https://github.com/nodejs/node/pull/48367)&#xD;&#xA;* \[[`5cc6eee30d`](https://github.com/nodejs/node/commit/5cc6eee30d)] - **doc**: add link for news from security wg (Michael Dawson) [#48396](https://github.com/nodejs/node/pull/48396)&#xD;&#xA;* \[[`ffece88452`](https://github.com/nodejs/node/commit/ffece88452)] - **doc**: fix typo in events.md (Darshan Sen) [#48436](https://github.com/nodejs/node/pull/48436)&#xD;&#xA;* \[[`06513585dc`](https://github.com/nodejs/node/commit/06513585dc)] - **doc**: run license-builder (github-actions\[bot]) [#48336](https://github.com/nodejs/node/pull/48336)&#xD;&#xA;* \[[`d9a800ee5c`](https://github.com/nodejs/node/commit/d9a800ee5c)] - **esm**: fix emit deprecation on legacy main resolve (Antoine du Hamel) [#48664](https://github.com/nodejs/node/pull/48664)&#xD;&#xA;* \[[`c39b7c240e`](https://github.com/nodejs/node/commit/c39b7c240e)] - **(SEMVER-MINOR)** **esm**: add `--import` flag (Moshe Atlow) [#43942](https://github.com/nodejs/node/pull/43942)&#xD;&#xA;* \[[`a00464ee06`](https://github.com/nodejs/node/commit/a00464ee06)] - **esm**: fix specifier resolution and symlinks (Zack Newsham) [#47674](https://github.com/nodejs/node/pull/47674)&#xD;&#xA;* \[[`3b8ec348b0`](https://github.com/nodejs/node/commit/3b8ec348b0)] - **events**: fix bug listenerCount don&#39;t compare wrapped listener (yuzheng14) [#48592](https://github.com/nodejs/node/pull/48592)&#xD;&#xA;* \[[`a68a67f54d`](https://github.com/nodejs/node/commit/a68a67f54d)] - **(SEMVER-MINOR)** **events**: allow safely adding listener to abortSignal (Chemi Atlow) [#48596](https://github.com/nodejs/node/pull/48596)&#xD;&#xA;* \[[`5354af3dab`](https://github.com/nodejs/node/commit/5354af3dab)] - **fs**: call the callback with an error if writeSync fails (killa) [#47949](https://github.com/nodejs/node/pull/47949)&#xD;&#xA;* \[[`c3a27d1d3d`](https://github.com/nodejs/node/commit/c3a27d1d3d)] - **fs**: remove unneeded return statement (Luigi Pinca) [#48526](https://github.com/nodejs/node/pull/48526)&#xD;&#xA;* \[[`3a8586bee2`](https://github.com/nodejs/node/commit/3a8586bee2)] - **fs, stream**: initial `Symbol.dispose` and `Symbol.asyncDispose` support (Moshe Atlow) [#48518](https://github.com/nodejs/node/pull/48518)&#xD;&#xA;* \[[`01746c71df`](https://github.com/nodejs/node/commit/01746c71df)] - **http**: null the joinDuplicateHeaders property on cleanup (Luigi Pinca) [#48608](https://github.com/nodejs/node/pull/48608)&#xD;&#xA;* \[[`d47eb73a85`](https://github.com/nodejs/node/commit/d47eb73a85)] - **http**: remove useless ternary in test (geekreal) [#48481](https://github.com/nodejs/node/pull/48481)&#xD;&#xA;* \[[`977e9a38b4`](https://github.com/nodejs/node/commit/977e9a38b4)] - **http**: fix for handling on boot timers headers and request (Franciszek Koltuniuk) [#48291](https://github.com/nodejs/node/pull/48291)&#xD;&#xA;* \[[`be88f7cd22`](https://github.com/nodejs/node/commit/be88f7cd22)] - **http2**: use addAbortListener (atlowChemi) [#48550](https://github.com/nodejs/node/pull/48550)&#xD;&#xA;* \[[`7c7230a85c`](https://github.com/nodejs/node/commit/7c7230a85c)] - **http2**: send RST code 8 on AbortController signal (Devraj Mehta) [#48573](https://github.com/nodejs/node/pull/48573)&#xD;&#xA;* \[[`f74c2fc72a`](https://github.com/nodejs/node/commit/f74c2fc72a)] - **lib**: use addAbortListener (atlowChemi) [#48550](https://github.com/nodejs/node/pull/48550)&#xD;&#xA;* \[[`db355d1f37`](https://github.com/nodejs/node/commit/db355d1f37)] - **lib**: add option to force handling stopped events (Chemi Atlow) [#48301](https://github.com/nodejs/node/pull/48301)&#xD;&#xA;* \[[`5d682c55a5`](https://github.com/nodejs/node/commit/5d682c55a5)] - **lib**: reduce url getters on `makeRequireFunction` (Yagiz Nizipli) [#48492](https://github.com/nodejs/node/pull/48492)&#xD;&#xA;* \[[`5260f53e55`](https://github.com/nodejs/node/commit/5260f53e55)] - **lib**: add support for inherited custom inspection methods (Antoine du Hamel) [#48306](https://github.com/nodejs/node/pull/48306)&#xD;&#xA;* \[[`69aaf8b1d1`](https://github.com/nodejs/node/commit/69aaf8b1d1)] - **lib**: remove invalid parameter to toASCII (Yagiz Nizipli) [#48878](https://github.com/nodejs/node/pull/48878)&#xD;&#xA;* \[[`51863b80e4`](https://github.com/nodejs/node/commit/51863b80e4)] - **meta**: bump actions/checkout from 3.5.2 to 3.5.3 (dependabot\[bot]) [#48625](https://github.com/nodejs/node/pull/48625)&#xD;&#xA;* \[[`7ec370991d`](https://github.com/nodejs/node/commit/7ec370991d)] - **meta**: bump step-security/harden-runner from 2.4.0 to 2.4.1 (dependabot\[bot]) [#48626](https://github.com/nodejs/node/pull/48626)&#xD;&#xA;* \[[`34b8e980d4`](https://github.com/nodejs/node/commit/34b8e980d4)] - **meta**: bump ossf/scorecard-action from 2.1.3 to 2.2.0 (dependabot\[bot]) [#48628](https://github.com/nodejs/node/pull/48628)&#xD;&#xA;* \[[`dfed9a7da9`](https://github.com/nodejs/node/commit/dfed9a7da9)] - **meta**: bump github/codeql-action from 2.3.6 to 2.20.1 (dependabot\[bot]) [#48627](https://github.com/nodejs/node/pull/48627)&#xD;&#xA;* \[[`071eaadc5a`](https://github.com/nodejs/node/commit/071eaadc5a)] - **module**: add SourceMap.findOrigin (Isaac Z. Schlueter) [#47790](https://github.com/nodejs/node/pull/47790)&#xD;&#xA;* \[[`bf1525c549`](https://github.com/nodejs/node/commit/bf1525c549)] - **module**: reduce url invocations in esm/load.js (Yagiz Nizipli) [#48337](https://github.com/nodejs/node/pull/48337)&#xD;&#xA;* \[[`f8921630a2`](https://github.com/nodejs/node/commit/f8921630a2)] - **net**: server add `asyncDispose` (atlowChemi) [#48717](https://github.com/nodejs/node/pull/48717)&#xD;&#xA;* \[[`b5f53d9a0b`](https://github.com/nodejs/node/commit/b5f53d9a0b)] - **net**: fix family autoselection SSL connection handling (Paolo Insogna) [#48189](https://github.com/nodejs/node/pull/48189)&#xD;&#xA;* \[[`267439fc34`](https://github.com/nodejs/node/commit/267439fc34)] - **net**: rework autoSelectFamily implementation (Paolo Insogna) [#46587](https://github.com/nodejs/node/pull/46587)&#xD;&#xA;* \[[`d3637cdbbf`](https://github.com/nodejs/node/commit/d3637cdbbf)] - **net**: fix address iteration with autoSelectFamily (Fedor Indutny) [#48258](https://github.com/nodejs/node/pull/48258)&#xD;&#xA;* \[[`e8289a83f1`](https://github.com/nodejs/node/commit/e8289a83f1)] - **net**: fix family autoselection timeout handling (Paolo Insogna) [#47860](https://github.com/nodejs/node/pull/47860)&#xD;&#xA;* \[[`863bdb785d`](https://github.com/nodejs/node/commit/863bdb785d)] - **net**: add autoSelectFamily global getter and setter (Paolo Insogna) [#45777](https://github.com/nodejs/node/pull/45777)&#xD;&#xA;* \[[`04dc090bfa`](https://github.com/nodejs/node/commit/04dc090bfa)] - **node-api**: provide napi\_define\_properties fast path (Gabriel Schulhof) [#48440](https://github.com/nodejs/node/pull/48440)&#xD;&#xA;* \[[`feb6a54dc3`](https://github.com/nodejs/node/commit/feb6a54dc3)] - **node-api**: implement external strings (Gabriel Schulhof) [#48339](https://github.com/nodejs/node/pull/48339)&#xD;&#xA;* \[[`121f74c463`](https://github.com/nodejs/node/commit/121f74c463)] - **perf\_hooks**: convert maxSize to IDL value in setResourceTimingBufferSize (Chengzhong Wu) [#44902](https://github.com/nodejs/node/pull/44902)&#xD;&#xA;* \[[`804d880589`](https://github.com/nodejs/node/commit/804d880589)] - **permission**: fix data types in PrintTree (Tobias Nießen) [#48770](https://github.com/nodejs/node/pull/48770)&#xD;&#xA;* \[[`7aaecce9bf`](https://github.com/nodejs/node/commit/7aaecce9bf)] - **permission**: add debug log when inserting fs nodes (Rafael Gonzaga) [#48677](https://github.com/nodejs/node/pull/48677)&#xD;&#xA;* \[[`cb51ef2905`](https://github.com/nodejs/node/commit/cb51ef2905)] - **readline**: use addAbortListener (atlowChemi) [#48550](https://github.com/nodejs/node/pull/48550)&#xD;&#xA;* \[[`07065d0814`](https://github.com/nodejs/node/commit/07065d0814)] - **report**: disable js stack when no context is entered (Chengzhong Wu) [#48495](https://github.com/nodejs/node/pull/48495)&#xD;&#xA;* \[[`572b82ffef`](https://github.com/nodejs/node/commit/572b82ffef)] - **src**: make BaseObject iteration order deterministic (Joyee Cheung) [#48702](https://github.com/nodejs/node/pull/48702)&#xD;&#xA;* \[[`3f65598a41`](https://github.com/nodejs/node/commit/3f65598a41)] - **src**: remove kEagerCompile for CompileFunction (Keyhan Vakil) [#48671](https://github.com/nodejs/node/pull/48671)&#xD;&#xA;* \[[`f43eacac9b`](https://github.com/nodejs/node/commit/f43eacac9b)] - **src**: deduplicate X509 getter implementations (Tobias Nießen) [#48563](https://github.com/nodejs/node/pull/48563)&#xD;&#xA;* \[[`0c19621bdc`](https://github.com/nodejs/node/commit/0c19621bdc)] - **src**: fix uninitialized field access in AsyncHooks (Jan Olaf Krems) [#48566](https://github.com/nodejs/node/pull/48566)&#xD;&#xA;* \[[`0c38184d62`](https://github.com/nodejs/node/commit/0c38184d62)] - **src**: fix Coverity issue regarding unnecessary copy (Yagiz Nizipli) [#48565](https://github.com/nodejs/node/pull/48565)&#xD;&#xA;* \[[`0d73009ba3`](https://github.com/nodejs/node/commit/0d73009ba3)] - **src**: refactor `SplitString` in util (Yagiz Nizipli) [#48491](https://github.com/nodejs/node/pull/48491)&#xD;&#xA;* \[[`6c72622df9`](https://github.com/nodejs/node/commit/6c72622df9)] - **src**: handle wasm out of bound in osx will raise SIGBUS correctly (Congcong Cai) [#46561](https://github.com/nodejs/node/pull/46561)&#xD;&#xA;* \[[`e4261809b0`](https://github.com/nodejs/node/commit/e4261809b0)] - **src**: replace idna functions with ada::idna (Yagiz Nizipli) [#47735](https://github.com/nodejs/node/pull/47735)&#xD;&#xA;* \[[`3dd82b1820`](https://github.com/nodejs/node/commit/3dd82b1820)] - **stream**: use addAbortListener (atlowChemi) [#48550](https://github.com/nodejs/node/pull/48550)&#xD;&#xA;* \[[`786fbdb824`](https://github.com/nodejs/node/commit/786fbdb824)] - **stream**: fix premature pipeline end (Robert Nagy) [#48435](https://github.com/nodejs/node/pull/48435)&#xD;&#xA;* \[[`c224e1b255`](https://github.com/nodejs/node/commit/c224e1b255)] - **stream**: fix deadlock when pipeing to full sink (Robert Nagy) [#48691](https://github.com/nodejs/node/pull/48691)&#xD;&#xA;* \[[`2c75b9ece2`](https://github.com/nodejs/node/commit/2c75b9ece2)] - **test**: fix flaky test-string-decode.js on x86 (Stefan Stojanovic) [#48750](https://github.com/nodejs/node/pull/48750)&#xD;&#xA;* \[[`279c4f64c1`](https://github.com/nodejs/node/commit/279c4f64c1)] - **test**: mark test-http-regr-gh-2928 as flaky (Joyee Cheung) [#49565](https://github.com/nodejs/node/pull/49565)&#xD;&#xA;* \[[`01eacccd9a`](https://github.com/nodejs/node/commit/01eacccd9a)] - **test**: deflake test-net-throttle (Luigi Pinca) [#48599](https://github.com/nodejs/node/pull/48599)&#xD;&#xA;* \[[`33886b271c`](https://github.com/nodejs/node/commit/33886b271c)] - **test**: move test-net-throttle to parallel (Luigi Pinca) [#48599](https://github.com/nodejs/node/pull/48599)&#xD;&#xA;* \[[`a79112b5f4`](https://github.com/nodejs/node/commit/a79112b5f4)] - _**Revert**_ &#34;**test**: remove test-crypto-keygen flaky designation&#34; (Luigi Pinca) [#48652](https://github.com/nodejs/node/pull/48652)&#xD;&#xA;* \[[`6ec57984db`](https://github.com/nodejs/node/commit/6ec57984db)] - **test**: add missing assertions to test-runner-cli (Moshe Atlow) [#48593](https://github.com/nodejs/node/pull/48593)&#xD;&#xA;* \[[`dd1805e802`](https://github.com/nodejs/node/commit/dd1805e802)] - **test**: remove test-crypto-keygen flaky designation (Luigi Pinca) [#48575](https://github.com/nodejs/node/pull/48575)&#xD;&#xA;* \[[`df9a9afc99`](https://github.com/nodejs/node/commit/df9a9afc99)] - **test**: remove test-timers-immediate-queue flaky designation (Luigi Pinca) [#48575](https://github.com/nodejs/node/pull/48575)&#xD;&#xA;* \[[`3ae96ae380`](https://github.com/nodejs/node/commit/3ae96ae380)] - **test**: make IsolateData per-isolate in cctest (Joyee Cheung) [#48450](https://github.com/nodejs/node/pull/48450)&#xD;&#xA;* \[[`f2ce8e0c06`](https://github.com/nodejs/node/commit/f2ce8e0c06)] - **test**: define NAPI\_VERSION before including node\_api.h (Chengzhong Wu) [#48376](https://github.com/nodejs/node/pull/48376)&#xD;&#xA;* \[[`13ac0a5e26`](https://github.com/nodejs/node/commit/13ac0a5e26)] - **test**: remove unnecessary noop function args to `mustNotCall()` (Antoine du Hamel) [#48513](https://github.com/nodejs/node/pull/48513)&#xD;&#xA;* \[[`8fdd4c55b3`](https://github.com/nodejs/node/commit/8fdd4c55b3)] - **test**: skip test-runner-watch-mode on IBMi (Moshe Atlow) [#48473](https://github.com/nodejs/node/pull/48473)&#xD;&#xA;* \[[`9d90409241`](https://github.com/nodejs/node/commit/9d90409241)] - **test**: fix flaky test-watch-mode (Moshe Atlow) [#48147](https://github.com/nodejs/node/pull/48147)&#xD;&#xA;* \[[`27a4bc7c32`](https://github.com/nodejs/node/commit/27a4bc7c32)] - **test**: add missing \&lt;algorithm&gt; include for std::find (Sam James) [#48380](https://github.com/nodejs/node/pull/48380)&#xD;&#xA;* \[[`cb92c4b9fe`](https://github.com/nodejs/node/commit/cb92c4b9fe)] - **test**: update url web-platform tests (Yagiz Nizipli) [#48319](https://github.com/nodejs/node/pull/48319)&#xD;&#xA;* \[[`f35c4d3190`](https://github.com/nodejs/node/commit/f35c4d3190)] - **test**: ignore the copied entry\_point.c (Luigi Pinca) [#48297](https://github.com/nodejs/node/pull/48297)&#xD;&#xA;* \[[`41d1e6888f`](https://github.com/nodejs/node/commit/41d1e6888f)] - **test**: refactor test-gc-http-client-timeout (Luigi Pinca) [#48292](https://github.com/nodejs/node/pull/48292)&#xD;&#xA;* \[[`125bca621a`](https://github.com/nodejs/node/commit/125bca621a)] - **test**: update encoding web-platform tests (Yagiz Nizipli) [#48320](https://github.com/nodejs/node/pull/48320)&#xD;&#xA;* \[[`e9ac111d02`](https://github.com/nodejs/node/commit/e9ac111d02)] - **test**: update FileAPI web-platform tests (Yagiz Nizipli) [#48322](https://github.com/nodejs/node/pull/48322)&#xD;&#xA;* \[[`3da57d17f5`](https://github.com/nodejs/node/commit/3da57d17f5)] - **test**: update user-timing web-platform tests (Yagiz Nizipli) [#48321](https://github.com/nodejs/node/pull/48321)&#xD;&#xA;* \[[`c728b8a29b`](https://github.com/nodejs/node/commit/c728b8a29b)] - **test**: fix `test-net-autoselectfamily` for kernel without IPv6 support (Livia Medeiros) [#45856](https://github.com/nodejs/node/pull/45856)&#xD;&#xA;* \[[`6de7aa1d19`](https://github.com/nodejs/node/commit/6de7aa1d19)] - **test**: move `test-tls-autoselectfamily-servername` to `test/internet` (Antoine du Hamel) [#47029](https://github.com/nodejs/node/pull/47029)&#xD;&#xA;* \[[`2de9868292`](https://github.com/nodejs/node/commit/2de9868292)] - **test**: validate host with commas on url.parse (Yagiz Nizipli) [#48878](https://github.com/nodejs/node/pull/48878)&#xD;&#xA;* \[[`e7d2e8ef2a`](https://github.com/nodejs/node/commit/e7d2e8ef2a)] - **test**: delete test-net-bytes-per-incoming-chunk-overhead (Michaël Zasso) [#48811](https://github.com/nodejs/node/pull/48811)&#xD;&#xA;* \[[`f5494fa1b0`](https://github.com/nodejs/node/commit/f5494fa1b0)] - **test\_runner**: fixed `test` shorthands return type (Shocker) [#48555](https://github.com/nodejs/node/pull/48555)&#xD;&#xA;* \[[`7051cafdfa`](https://github.com/nodejs/node/commit/7051cafdfa)] - **test\_runner**: make `--test-name-pattern` recursive (Moshe Atlow) [#48382](https://github.com/nodejs/node/pull/48382)&#xD;&#xA;* \[[`f302286442`](https://github.com/nodejs/node/commit/f302286442)] - **test\_runner**: refactor coverage report output for readability (Damien Seguin) [#47791](https://github.com/nodejs/node/pull/47791)&#xD;&#xA;* \[[`7822a541e5`](https://github.com/nodejs/node/commit/7822a541e5)] - **timers**: support Symbol.dispose (Moshe Atlow) [#48633](https://github.com/nodejs/node/pull/48633)&#xD;&#xA;* \[[`3eeca52db1`](https://github.com/nodejs/node/commit/3eeca52db1)] - **tls**: fix bugs of double TLS (rogertyang) [#48969](https://github.com/nodejs/node/pull/48969)&#xD;&#xA;* \[[`4826379516`](https://github.com/nodejs/node/commit/4826379516)] - **tools**: run fetch\_deps.py with Python 3 (Richard Lau) [#48729](https://github.com/nodejs/node/pull/48729)&#xD;&#xA;* \[[`e2688c8d79`](https://github.com/nodejs/node/commit/e2688c8d79)] - **tools**: update doc to unist-util-select\@5.0.0 unist-util-visit\@5.0.0 (Node.js GitHub Bot) [#48714](https://github.com/nodejs/node/pull/48714)&#xD;&#xA;* \[[`7399481096`](https://github.com/nodejs/node/commit/7399481096)] - **tools**: update lint-md-dependencies to rollup\@3.26.2 (Node.js GitHub Bot) [#48705](https://github.com/nodejs/node/pull/48705)&#xD;&#xA;* \[[`31c07153ce`](https://github.com/nodejs/node/commit/31c07153ce)] - **tools**: update eslint to 8.44.0 (Node.js GitHub Bot) [#48632](https://github.com/nodejs/node/pull/48632)&#xD;&#xA;* \[[`4e53f51e24`](https://github.com/nodejs/node/commit/4e53f51e24)] - **tools**: update lint-md-dependencies to rollup\@3.26.0 (Node.js GitHub Bot) [#48631](https://github.com/nodejs/node/pull/48631)&#xD;&#xA;* \[[`7d52950a96`](https://github.com/nodejs/node/commit/7d52950a96)] - **tools**: update lint-md-dependencies (Node.js GitHub Bot) [#48544](https://github.com/nodejs/node/pull/48544)&#xD;&#xA;* \[[`e168eab3ee`](https://github.com/nodejs/node/commit/e168eab3ee)] - **tools**: update lint-md-dependencies (Node.js GitHub Bot) [#48486](https://github.com/nodejs/node/pull/48486)&#xD;&#xA;* \[[`9711bc24f6`](https://github.com/nodejs/node/commit/9711bc24f6)] - **tools**: replace sed with perl (Luigi Pinca) [#48499](https://github.com/nodejs/node/pull/48499)&#xD;&#xA;* \[[`9c1937c0a7`](https://github.com/nodejs/node/commit/9c1937c0a7)] - **tools**: update eslint to 8.43.0 (Node.js GitHub Bot) [#48487](https://github.com/nodejs/node/pull/48487)&#xD;&#xA;* \[[`9449f05ab1`](https://github.com/nodejs/node/commit/9449f05ab1)] - **tools**: update doc to to-vfile\@8.0.0 (Node.js GitHub Bot) [#48485](https://github.com/nodejs/node/pull/48485)&#xD;&#xA;* \[[`79dcd968b1`](https://github.com/nodejs/node/commit/79dcd968b1)] - **tools**: prepare tools/doc for to-vfile 8.0.0 (Rich Trott) [#48485](https://github.com/nodejs/node/pull/48485)&#xD;&#xA;* \[[`538f388ac0`](https://github.com/nodejs/node/commit/538f388ac0)] - **tools**: update lint-md-dependencies (Node.js GitHub Bot) [#48417](https://github.com/nodejs/node/pull/48417)&#xD;&#xA;* \[[`01bc10dcd5`](https://github.com/nodejs/node/commit/01bc10dcd5)] - **tools**: update create-or-update-pull-request-action (Richard Lau) [#48398](https://github.com/nodejs/node/pull/48398)&#xD;&#xA;* \[[`590a072657`](https://github.com/nodejs/node/commit/590a072657)] - **tools**: update eslint-plugin-jsdoc (Richard Lau) [#48393](https://github.com/nodejs/node/pull/48393)&#xD;&#xA;* \[[`6a5805491e`](https://github.com/nodejs/node/commit/6a5805491e)] - **tools**: update eslint to 8.42.0 (Node.js GitHub Bot) [#48328](https://github.com/nodejs/node/pull/48328)&#xD;&#xA;* \[[`2eb13e3986`](https://github.com/nodejs/node/commit/2eb13e3986)] - **tools**: disable jsdoc/no-defaults rule (Luigi Pinca) [#48328](https://github.com/nodejs/node/pull/48328)&#xD;&#xA;* \[[`3363cfa6c7`](https://github.com/nodejs/node/commit/3363cfa6c7)] - **typings**: remove unused primordials (Yagiz Nizipli) [#48509](https://github.com/nodejs/node/pull/48509)&#xD;&#xA;* \[[`c59ae86ba0`](https://github.com/nodejs/node/commit/c59ae86ba0)] - **(SEMVER-MINOR)** **url**: add value argument to has and delete methods (Sankalp Shubham) [#47885](https://github.com/nodejs/node/pull/47885)&#xD;&#xA;* \[[`f59c9636f4`](https://github.com/nodejs/node/commit/f59c9636f4)] - **url**: conform to origin getter spec changes (Yagiz Nizipli) [#48319](https://github.com/nodejs/node/pull/48319)&#xD;&#xA;* \[[`0beb5ab93d`](https://github.com/nodejs/node/commit/0beb5ab93d)] - **url**: ensure getter access do not mutate observable symbols (Antoine du Hamel) [#48897](https://github.com/nodejs/node/pull/48897)&#xD;&#xA;* \[[`0a022c496d`](https://github.com/nodejs/node/commit/0a022c496d)] - **util**: use `primordials.ArrayPrototypeIndexOf` instead of mutable method (DaisyDogs07) [#48586](https://github.com/nodejs/node/pull/48586)&#xD;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

