### PR TITLE
Jdk25

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -43,19 +43,18 @@ RUN apk add --no-cache \
 
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
-RUN JLINK_COMMON_OPTS="--strip-java-debug-attributes --no-man-pages --no-header-files --output /javaruntime"; \
-  case "$(jlink --version 2>&1)" in \
-    "17."*) jlink $JLINK_COMMON_OPTS \
-      --compress=2 \
-      --add-modules ALL-MODULE-PATH ;; \
-    "21."*) jlink $JLINK_COMMON_OPTS \
-      --compress=zip-6 \
-      --add-modules ALL-MODULE-PATH ;; \
-    "25"*) jlink $JLINK_COMMON_OPTS \
-      --compress=zip-6 \
-      --add-modules java.base,java.logging,java.xml,java.se ;; \
+RUN case "$(jlink --version 2>&1)" in \
+    "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
+    "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.se ;; \
     *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-  esac
+  esac; \
+  jlink \
+    --strip-java-debug-attributes \
+    "$@" \
+    --no-man-pages \
+    --no-header-files \
+    --output /javaruntime
 
 FROM alpine:"${ALPINE_TAG}" AS build
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -46,7 +46,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 RUN case "$(jlink --version 2>&1)" in \
     "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
     "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
-    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.se ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.se ;; \
     *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
   esac; \
   jlink \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -43,30 +43,19 @@ RUN apk add --no-cache \
 
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
-RUN case "$(jlink --version 2>&1)" in \
-      "17."*) jlink \
-        --strip-java-debug-attributes \
-        --compress=2 \
-        --add-modules ALL-MODULE-PATH \
-        --no-man-pages \
-        --no-header-files \
-        --output /javaruntime ;; \
-      "21."*) jlink \
-        --strip-java-debug-attributes \
-        --compress=zip-6 \
-        --add-modules ALL-MODULE-PATH \
-        --no-man-pages \
-        --no-header-files \
-        --output /javaruntime ;; \
-      "25"*) jlink \
-        --strip-java-debug-attributes \
-        --compress=zip-6 \
-        --add-modules java.base,java.logging,java.xml,java.se \
-        --no-man-pages \
-        --no-header-files \
-        --output /javaruntime ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-    esac
+RUN JLINK_COMMON_OPTS="--strip-java-debug-attributes --no-man-pages --no-header-files --output /javaruntime"; \
+  case "$(jlink --version 2>&1)" in \
+    "17."*) jlink $JLINK_COMMON_OPTS \
+      --compress=2 \
+      --add-modules ALL-MODULE-PATH ;; \
+    "21."*) jlink $JLINK_COMMON_OPTS \
+      --compress=zip-6 \
+      --add-modules ALL-MODULE-PATH ;; \
+    "25"*) jlink $JLINK_COMMON_OPTS \
+      --compress=zip-6 \
+      --add-modules java.base,java.logging,java.xml,java.se ;; \
+    *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+  esac
 
 FROM alpine:"${ALPINE_TAG}" AS build
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -44,18 +44,29 @@ RUN apk add --no-cache \
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
+      "17."*) jlink \
+        --strip-java-debug-attributes \
+        --compress=2 \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --no-header-files \
+        --output /javaruntime ;; \
+      "21."*) jlink \
+        --strip-java-debug-attributes \
+        --compress=zip-6 \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --no-header-files \
+        --output /javaruntime ;; \
+      "25"*) jlink \
+        --strip-java-debug-attributes \
+        --compress=zip-6 \
+        --add-modules java.base,java.logging,java.xml,java.se \
+        --no-man-pages \
+        --no-header-files \
+        --output /javaruntime ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-    esac; \
-    jlink \
-      --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
-      --no-man-pages \
-      --no-header-files \
-      --output /javaruntime
+    esac
 
 FROM alpine:"${ALPINE_TAG}" AS build
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -46,7 +46,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 RUN case "$(jlink --version 2>&1)" in \
     "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
     "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
-    "25"*) set -- "--compress=zip-6" --add-modules java.se ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec ;; \
     *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
   esac; \
   jlink \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,19 +45,18 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN JLINK_COMMON_OPTS="--strip-java-debug-attributes --no-man-pages --no-header-files --output /javaruntime"; \
-  case "$(jlink --version 2>&1)" in \
-    "17."*) jlink $JLINK_COMMON_OPTS \
-      --compress=2 \
-      --add-modules ALL-MODULE-PATH ;; \
-    "21."*) jlink $JLINK_COMMON_OPTS \
-      --compress=zip-6 \
-      --add-modules ALL-MODULE-PATH ;; \
-    "25"*) jlink $JLINK_COMMON_OPTS \
-      --compress=zip-6 \
-      --add-modules java.base,java.logging,java.xml,java.se ;; \
+RUN case "$(jlink --version 2>&1)" in \
+    "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
+    "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.se ;; \
     *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-  esac
+  esac; \
+  jlink \
+    --strip-java-debug-attributes \
+    "$@" \
+    --no-man-pages \
+    --no-header-files \
+    --output /javaruntime
 
 FROM debian:"${DEBIAN_RELEASE}"
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -46,18 +46,29 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
+      "17."*) jlink \
+        --strip-java-debug-attributes \
+        --compress=2 \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --no-header-files \
+        --output /javaruntime ;; \
+      "21."*) jlink \
+        --strip-java-debug-attributes \
+        --compress=zip-6 \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --no-header-files \
+        --output /javaruntime ;; \
+      "25"*) jlink \
+        --strip-java-debug-attributes \
+        --compress=zip-6 \
+        --add-modules java.base,java.logging,java.xml,java.se \
+        --no-man-pages \
+        --no-header-files \
+        --output /javaruntime ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-    esac; \
-    jlink \
-      --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
-      --no-man-pages \
-      --no-header-files \
-      --output /javaruntime
+    esac
 
 FROM debian:"${DEBIAN_RELEASE}"
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,30 +45,19 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN case "$(jlink --version 2>&1)" in \
-      "17."*) jlink \
-        --strip-java-debug-attributes \
-        --compress=2 \
-        --add-modules ALL-MODULE-PATH \
-        --no-man-pages \
-        --no-header-files \
-        --output /javaruntime ;; \
-      "21."*) jlink \
-        --strip-java-debug-attributes \
-        --compress=zip-6 \
-        --add-modules ALL-MODULE-PATH \
-        --no-man-pages \
-        --no-header-files \
-        --output /javaruntime ;; \
-      "25"*) jlink \
-        --strip-java-debug-attributes \
-        --compress=zip-6 \
-        --add-modules java.base,java.logging,java.xml,java.se \
-        --no-man-pages \
-        --no-header-files \
-        --output /javaruntime ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-    esac
+RUN JLINK_COMMON_OPTS="--strip-java-debug-attributes --no-man-pages --no-header-files --output /javaruntime"; \
+  case "$(jlink --version 2>&1)" in \
+    "17."*) jlink $JLINK_COMMON_OPTS \
+      --compress=2 \
+      --add-modules ALL-MODULE-PATH ;; \
+    "21."*) jlink $JLINK_COMMON_OPTS \
+      --compress=zip-6 \
+      --add-modules ALL-MODULE-PATH ;; \
+    "25"*) jlink $JLINK_COMMON_OPTS \
+      --compress=zip-6 \
+      --add-modules java.base,java.logging,java.xml,java.se ;; \
+    *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+  esac
 
 FROM debian:"${DEBIAN_RELEASE}"
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -48,7 +48,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 RUN case "$(jlink --version 2>&1)" in \
     "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
     "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
-    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.se ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.se ;; \
     *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
   esac; \
   jlink \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -48,7 +48,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 RUN case "$(jlink --version 2>&1)" in \
     "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
     "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
-    "25"*) set -- "--compress=zip-6" --add-modules java.se ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec ;; \
     *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
   esac; \
   jlink \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,6 +32,10 @@ group "linux-ppc64le" {
 }
 
 variable "jdks_to_build" {
+  default = [17, 21, 25]
+}
+
+variable "jdks_to_build_windows" {
   default = [17, 21]
 }
 
@@ -71,6 +75,10 @@ variable "JAVA21_VERSION" {
   default = "21.0.8_9"
 }
 
+variable "JAVA25_VERSION" {
+  default = "25+9-ea-beta"
+}
+
 variable "DEBIAN_RELEASE" {
   default = "trixie-20250908"
 }
@@ -92,16 +100,18 @@ function "javaversion" {
   params = [jdk]
   result = (equal(17, jdk)
     ? "${JAVA17_VERSION}"
-  : "${JAVA21_VERSION}")
+  : equal(21, jdk)
+    ? "${JAVA21_VERSION}"
+  : "${JAVA25_VERSION}")
 }
 
 ## Specific functions
 # Return an array of Alpine platforms to use depending on the jdk passed as parameter
 function "alpine_platforms" {
   params = [jdk]
-  result = (equal(21, jdk)
-    ? ["linux/amd64", "linux/arm64"]
-  : ["linux/amd64"])
+  result = (equal(17, jdk)
+    ? ["linux/amd64"]
+    : ["linux/amd64", "linux/arm64"])
 }
 
 # Return an array of Debian platforms to use depending on the jdk passed as parameter
@@ -191,7 +201,7 @@ target "debian" {
 
 target "nanoserver" {
   matrix = {
-    jdk             = jdks_to_build
+    jdk             = jdks_to_build_windows
     windows_version = windowsversions("nanoserver")
   }
   name       = "nanoserver-${windows_version}_jdk${jdk}"
@@ -216,7 +226,7 @@ target "nanoserver" {
 
 target "windowsservercore" {
   matrix = {
-    jdk             = jdks_to_build
+    jdk             = jdks_to_build_windows
     windows_version = windowsversions("windowsservercore")
   }
   name       = "windowsservercore-${windows_version}_jdk${jdk}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added official JDK 25 image variants for Linux and Windows.
  - Updated Windows images to use Windows-specific JDK builds.
  - Expanded multi-arch support for JDK 21 and 25; JDK 17 remains single-arch.

- Refactor
  - Consolidated and standardized runtime packaging/options per JDK version, with optimized runtime layout for JDK 25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->